### PR TITLE
Add .blade route blocker

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,5 +21,14 @@ Kirby::plugin('afbora/blade', [
         'template' => function (Kirby $kirby, string $name, string $contentType = null) {
             return new Template($kirby, $name, $contentType);
         }
+    ],
+    'routes' => [
+        [
+            // Block all requests to /url.blade and return 404
+            'pattern' => '(:all)\.blade',
+            'action' => function ($all) {
+                return false;
+            }
+        ]
     ]
 ]);

--- a/src/Template.php
+++ b/src/Template.php
@@ -362,7 +362,9 @@ class Template extends KirbyTemplate
             }
         }
 
-        $name = $this->name() . "." . $this->type();
+        // disallow blade extension for content representation, for ex: /blog.blade
+        $type = $this->type() === 'blade' ? 'php' : $this->type();
+        $name = $this->name() . "." . $type;
 
         try {
             // Try the template with type extension in the default template directory.


### PR DESCRIPTION
Disallow all `(domain)/(url).blade` URLs to prevent Kirby from displaying raw blade templates as a content representation.